### PR TITLE
Only update a subdirectory of neubot-runtime

### DIFF
--- a/scripts/update_deps.sh
+++ b/scripts/update_deps.sh
@@ -2,25 +2,18 @@
 # Clone specific tags from github and update local copy
 
 get() {
+  (cd neubot/ && rm -rf $3)
   git clone https://github.com/$1 tmp/$1
   (cd tmp/$1 && git checkout $2)
-  (cd tmp/$1 && git archive --prefix=$3/ HEAD) | \
+  (cd tmp/$1 && git archive --prefix=$3/ HEAD$4) | \
     (cd neubot/ && tar -xf-)
 }
 
-rm -rf tmp/*
-get DavideAllavena/neubot-mod-speedtest 339e1e8 mod_speedtest
-get DavideAllavena/neubot-mod-bittorrent  7d837de mod_bittorrent
-get DavideAllavena/neubot-mod-dash d556977 mod_dash
-get DavideAllavena/neubot-mod-raw-test 9a6b74e mod_raw_test
-get DavideAllavena/neubot-negotiate b0211ac negotiate
 rm -rf tmp
-
-
-# XXX Quick fix just to import the needed dir
-git clone https://github.com/bassosimone/neubot-runtime tmp/neubot-runtime 
-(cd tmp/neubot-runtime && git checkout v1.0.0-alpha.1)
-cp -R tmp/neubot-runtime/neubot_runtime/* neubot/runtime/
+get DavideAllavena/neubot-mod-speedtest master mod_speedtest
+get DavideAllavena/neubot-mod-bittorrent  master mod_bittorrent
+get DavideAllavena/neubot-mod-dash master mod_dash
+get DavideAllavena/neubot-mod-raw-test master mod_raw_test
+get DavideAllavena/neubot-negotiate master negotiate
+get bassosimone/neubot-runtime master runtime ':neubot_runtime/'
 rm -rf tmp
-
-


### PR DESCRIPTION
While there, point all repositories to master rather than to a specific commit, for simplicity of maintenance.
